### PR TITLE
fix #19

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,10 @@ Authors@R: c(person("Carl", "Boettiger",
                     comment = c(ORCID = "0000-0002-1642-628X")),
              person("Mark", "Padgham", 
                      role = c("ctb"),
-                     comment = c(ORCID = "0000-0003-2172-5265")))
+                     comment = c(ORCID = "0000-0003-2172-5265")),
+             person(c('Jeffrey', 'O'), 'Hanson',
+                    role = c("ctb"),
+                    comment = c(ORCID = "0000-0002-4716-6134")))
 URL: https://github.com/ropensci/piggyback
 BugReports: https://github.com/ropensci/piggyback/issues
 License: GPL-3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: piggyback
-Version: 0.0.8
+Version: 0.0.9
 Title: Managing Larger Data on a GitHub Repository
 Description: Because larger (> 50 MB) data files cannot easily be committed to git,
   a different approach is required to manage data associated with an analysis in a 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# piggyback 0.0.9
+
+* Enable re-upload and deletion of partially uploaded files (#19)
+
 # piggyback 0.0.8
 
 * Updates to documentation, streamlining tests


### PR DESCRIPTION
This pull request address #19. Specifically, `piggyback:::release_info` will now download asset metadata (i.e. information about files attached to GitHub releases) for each release separately in a series of follow up calls to the GitHub API. This update means that information on partially uploaded files is propagated into the `pb_list` function, and in turn, the `pb_delete` function so that users can delete partially uploaded files using `pb_delete`. Please note that although I ran `devtools::test()` locally on my machine, I was unable to run all the tests because my system does not have the  environmental variable (i.e. `CBOETTIG_TOKEN`).