### PR TITLE
avoid default pagination limits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: piggyback
-Version: 0.0.9
+Version: 0.0.10
 Title: Managing Larger Data on a GitHub Repository
 Description: Because larger (> 50 MB) data files cannot easily be committed to git,
   a different approach is required to manage data associated with an analysis in a 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,25 +1,33 @@
-# piggyback 0.0.9
+# piggyback 0.0.10
+
+* Bugfixes for errors introduced in 0.0.9: 
+   - Uploading of directory paths could cause download errors in `pb_download()`. (#24)
+   - Access all assets on a release instead of first 30.  This could break upload and download. (#23, #24)
+
+# piggyback 0.0.9, 2019-01-08
 
 * Enable re-upload and deletion of partially uploaded files (#19)
 
-# piggyback 0.0.8
+# piggyback 0.0.8, 2018-10-06
 
 * Updates to documentation, streamlining tests
 * remove dependency on `utils::askYesNo` which is only available in R >= 3.5.0
 
-# piggyback 0.0.7 2018-10-01
+# piggyback 0.0.7, 2018-09-30
 
 * Initial release to CRAN
 
-# piggyback 0.0.6 2018-09-21
+--------------------------------------------
+
+# piggyback 0.0.6, 2018-09-21
 
 * bugfix for migrating unit test
 
-# piggyback 0.0.6 2018-09-21
+# piggyback 0.0.6, 2018-09-21
 
 * bugfix for migrating unit test, JOSS submission
 
-# piggyback 0.0.5 2018-09-21
+# piggyback 0.0.5, 2018-09-21
 
 * initial Onboarding to rOpenSci
 

--- a/R/pb_info.R
+++ b/R/pb_info.R
@@ -10,7 +10,9 @@ release_info <- function(repo = guess_repo(), .token = get_token()) {
 
   # get release ids
   releases <- maybe(gh::gh("/repos/:owner/:repo/releases",
-                           owner = r[[1]], repo = r[[2]], .token = .token
+                           owner = r[[1]], repo = r[[2]],
+                           .limit = Inf,
+                           .token = .token
   ),
   otherwise = stop(api_error_msg(r))
   )
@@ -18,7 +20,10 @@ release_info <- function(repo = guess_repo(), .token = get_token()) {
   # fetch asset meta-data individually, see #19
   for (i in seq_along(releases)) {
      a <- gh::gh(endpoint = "/repos/:owner/:repo/releases/:release_id/assets",
-                 owner = r[[1]], repo = r[[2]], release_id = releases[[i]]$id,
+                 owner = r[[1]],
+                 repo = r[[2]],
+                 release_id = releases[[i]]$id,
+                 .limit = Inf,
                  .token = .token)
      if (!identical(a[[1]], "")) {
       # if the i'th release does not have any assets then we skip updating
@@ -28,7 +33,7 @@ release_info <- function(repo = guess_repo(), .token = get_token()) {
       releases[[i]]$assets <- a
     }
   }
-  
+
   # return result
   releases
 }

--- a/R/pb_info.R
+++ b/R/pb_info.R
@@ -25,9 +25,16 @@ release_info <- function(repo = guess_repo(), .token = get_token()) {
                  release_id = releases[[i]]$id,
                  .limit = Inf,
                  .token = .token)
+
      if (!identical(a[[1]], "")) {
       # if the i'th release does not have any assets then we skip updating
       # the assets in the releases object
+
+       ## first, drop any non-file assets (e.g. base directories) from the list
+       drop <- vapply(a, `[[`, character(1L), "state") == "starter"
+       a[drop] <- NULL
+
+      ## Now use assets given by the release id as the returned assets
       class(a) <- "list"
       attributes(a) <- NULL
       releases[[i]]$assets <- a
@@ -56,6 +63,7 @@ release_data <- function(x, r) {
       upload_url = x$upload_url,
       browser_download_url = "",
       id = "",
+      state = "",
       stringsAsFactors = FALSE
     ))
 
@@ -79,8 +87,14 @@ release_data <- function(x, r) {
       "browser_download_url"
     ),
     id = vapply(x$assets, `[[`, integer(1), "id"),
+    state = null_chr(x$state),
     stringsAsFactors = FALSE
   )
+}
+
+null_chr <- function(x){
+  if(is.null(x)) return("")
+  as.character(NA)
 }
 
 pb_info_fn <- function(repo = guess_repo(),
@@ -147,3 +161,5 @@ pb_info <- function(repo = guess_repo(),
   }
 
 }
+
+


### PR DESCRIPTION
0.9 created a bug by introducing call to gh inside pb_info() (and thus all core functions using that method) which used left the default number of items (30) in place for assets returned. This patch makes sure we get all assets attached to the release.  

@karinorman can you check this when you get a chance? I think this should fix both issues you spotted in #23.  (previously you could not upload because piggyback didn't know it needed to delete the existing version, since it only saw the first 30 items due to this bug.  similarly, it would only download the first 30 items, all of which were in `col`).  