### PR TITLE
attempt at patching starter upload error

### DIFF
--- a/R/pb_download.R
+++ b/R/pb_download.R
@@ -56,6 +56,9 @@ pb_download <- function(file = NULL,
 
   df <- pb_info(repo, tag, .token)
 
+  ## drop failed upload states from list
+  df <- df[df$state != "starter",]
+
   if (!is.null(file)) {
     i <- which(df$file_name %in% file)
     if (length(i) < 1) {

--- a/R/pb_info.R
+++ b/R/pb_info.R
@@ -30,10 +30,6 @@ release_info <- function(repo = guess_repo(), .token = get_token()) {
       # if the i'th release does not have any assets then we skip updating
       # the assets in the releases object
 
-       ## first, drop any non-file assets (e.g. base directories) from the list
-       drop <- vapply(a, `[[`, character(1L), "state") == "starter"
-       a[drop] <- NULL
-
       ## Now use assets given by the release id as the returned assets
       class(a) <- "list"
       attributes(a) <- NULL
@@ -83,11 +79,11 @@ release_data <- function(x, r) {
     repo = r[[2]],
     upload_url = x$upload_url,
     browser_download_url = vapply(
-      x$assets, `[[`, character(1),
+      x$assets, `[[`, character(1L),
       "browser_download_url"
     ),
-    id = vapply(x$assets, `[[`, integer(1), "id"),
-    state = null_chr(x$state),
+    id = vapply(x$assets, `[[`, integer(1L), "id"),
+    state = vapply(x$assets, `[[`, character(1L), "state"),
     stringsAsFactors = FALSE
   )
 }


### PR DESCRIPTION
Better handling of failed uploads

Dropping failed uploads from the list just got us back to the 0.0.8 behavior.  Here, we identify failed uploads in the `pb_info()` table's `state` column, as returned by the assets API endpoint, which allows `pb_upload()` to successfully recognize and overwrite them.  Importantly, we drop these from the `pb_download()` call, otherwise these failed-state entries cause the download to fail.  