### PR TITLE
Authorization in header

### DIFF
--- a/R/pb_download.R
+++ b/R/pb_download.R
@@ -141,14 +141,26 @@ gh_download_asset <- function(owner,
     paste0(
       "https://",
       "api.github.com/repos/", owner, "/",
-      repo, "/", "releases/assets/", id#,
-      #"?access_token=", .token
+      repo, "/", "releases/assets/", id
     ),
-    httr::add_headers(Authorization = paste0("token ",.token), Accept = "application/octet-stream"),
+    httr::add_headers(Accept = "application/octet-stream"),
+    httr::add_headers(Authorization = paste("token",.token)),
     httr::write_disk(destfile, overwrite = overwrite),
     progress
   )
-  ## handle error cases? resp not found
+
+  # Try to use the redirection URL instead in case of "bad request"
+  # See https://gist.github.com/josh-padnick/fdae42c07e648c798fc27dec2367da21
+  if (resp$status_code == 400) {
+    resp <- httr::GET(
+      resp$url,
+      httr::add_headers(Accept = "application/octet-stream"),
+      httr::write_disk(destfile, overwrite = T),
+      progress
+    )
+  }
+
+  # handle error cases? resp not found
   httr::stop_for_status(resp)
   invisible(resp)
 }

--- a/R/pb_download.R
+++ b/R/pb_download.R
@@ -139,11 +139,12 @@ gh_download_asset <- function(owner,
 
   resp <- httr::GET(
     paste0(
-      "https://api.github.com/repos/", owner, "/",
-      repo, "/", "releases/assets/", id,
-      "?access_token=", .token
+      "https://",
+      "api.github.com/repos/", owner, "/",
+      repo, "/", "releases/assets/", id#,
+      #"?access_token=", .token
     ),
-    httr::add_headers(Accept = "application/octet-stream"),
+    httr::add_headers(Authorization = paste0("token ",.token), Accept = "application/octet-stream"),
     httr::write_disk(destfile, overwrite = overwrite),
     progress
   )


### PR DESCRIPTION
As github will soon not allow for query authentication, this is the implementation of the authentication header alternative for `pb_downoad`. Unfortunately, this creates problems for private repositories where the authorisation is duplicated in the redirection URL and the request ends up in a "bad request" status. In this case, the download request is done again using the redirection URL without the authorization header.

Full credit to https://gist.github.com/josh-padnick/fdae42c07e648c798fc27dec2367da21 for the trick. 