### PR TITLE
Minor doc adjustment

### DIFF
--- a/R/pb_download.R
+++ b/R/pb_download.R
@@ -29,7 +29,7 @@
 #' @examples \donttest{
 #'  ## Download a specific file.
 #'  ## (dest can be omitted when run inside and R project)
-#'  piggyback::pb_download("data/iris.tsv.gz",
+#'  piggyback::pb_download("data/iris.tsv.xz",
 #'                         repo = "cboettig/piggyback-tests",
 #'                         dest = tempdir())
 #' }

--- a/man/pb_download.Rd
+++ b/man/pb_download.Rd
@@ -55,7 +55,7 @@ Download data from an existing release
 \donttest{
  ## Download a specific file.
  ## (dest can be omitted when run inside and R project)
- piggyback::pb_download("data/iris.tsv.gz",
+ piggyback::pb_download("data/iris.tsv.xz",
                         repo = "cboettig/piggyback-tests",
                         dest = tempdir())
 }


### PR DESCRIPTION
Was working with the examples trying to test them out. Current example for `pb_download()` refers to data/iris.tsv.gz, however that file doesn't appear to exist: 

```
> pb_list(repo = "cboettig/piggyback-tests")
           file_name size           timestamp    tag    owner            repo
1   data/iris.tsv.xz  848 2020-08-19 00:12:17 v0.0.1 cboettig piggyback-tests
2 data/mtcars.tsv.gz  557 2020-08-19 00:12:18 v0.0.1 cboettig piggyback-tests
3        iris.tsv.gz  846 2020-08-19 00:12:16 v0.0.1 cboettig piggyback-tests
4        iris.tsv.xz  848 2020-03-07 06:18:32 v0.0.1 cboettig piggyback-tests
5       iris2.tsv.gz  846 2018-10-05 17:04:33 v0.0.1 cboettig piggyback-tests
```

Updating doc to use `xz` version instead. 

@cboettig These examples also use a tempdir() which, if someone were wondering where the file went, may not be clear if they don't know what tempdir() does. Recommend removing and allowing the example to be created in the current project directory. 

I'm using this for a $ supported project. So if there's something else you need to get this pushed to CRAN (per #41 ) promptly please direct me to how I can assist as I can provide seom dev time. 
