### PR TITLE
fix incorrect file destination index specification for gh_download_asset in pb_download when local files missing

### DIFF
--- a/R/pb_download.R
+++ b/R/pb_download.R
@@ -94,7 +94,7 @@ pb_download <- function(file = NULL,
     gh_download_asset(df$owner[[1]],
                       df$repo[[1]],
                       id = df$id[i],
-                      destfile = dest[i],
+                      destfile = df$dest[i],
                       overwrite = overwrite,
                       progress = progress
     ))


### PR DESCRIPTION
A small bug fix where if a local file is missing from an already downloaded release, the correct file is downloaded but overwrites the first file listed in the release.

This is shown in the following reprex where if the release files are downloaded for the example repo and one of the files is subsequently deleted (`mtcars.tsv.gz`). Running `pb_download` again will download `mtcars.tsv.gz`but overwrite the `diamonds.tsv.gz` file. 

```
> temp_dir <- tempdir()
> 
> piggyback::pb_download(repo = "cboettig/piggyback-tests",
+                        dest = temp_dir)
downloading diamonds.tsv.gz ...
  |=========================================| 100%
downloading mtcars.tsv.gz ...
  |=========================================| 100%
> 
> tools::md5sum(list.files(temp_dir,
+                          pattern = '.tsv.gz',
+                          full.names = TRUE))
   /tmp/RtmpSeRhtc/diamonds.tsv.gz 
"b4ce5ecaa26338ec733032a7369660cb" 
     /tmp/RtmpSeRhtc/mtcars.tsv.gz 
"10bd19ad61e72b9ba14c6d4f0d26e651" 
> 
> unlink(paste0(temp_dir,'/mtcars.tsv.gz'))
> 
> piggyback::pb_download(repo = "cboettig/piggyback-tests",
+                        dest = temp_dir)
downloading diamonds.tsv.gz ...
  |=========================================| 100%
> 
> tools::md5sum(list.files(temp_dir,
+                          pattern = '.tsv.gz',
+                          full.names = TRUE))
   /tmp/RtmpSeRhtc/diamonds.tsv.gz 
"10bd19ad61e72b9ba14c6d4f0d26e651"
```