### PR TITLE
Use verbose option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: piggyback
-Version: 0.1.1.9002
+Version: 0.1.1.9003
 Title: Managing Larger Data on a GitHub Repository
 Description: Because larger (> 50 MB) data files cannot easily be committed to git,
   a different approach is required to manage data associated with an analysis in a 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * `pb_upload()` is now the only function that offers (interactively) to create a new release if release is not found. If noninteractive, user must run `pb_new_release()` manually prior to uploading. 
 * CLI messaging now consistently uses `{cli}` package and no longer uses clisymbols or crayon - this is to align with the imports from the `{gh}` package.
 * Documentation updated.
+* Add options("piggyback.verbose") TRUE/FALSE to control verbosity/messaging levels.
 
 # piggyback 0.1.1
 

--- a/R/pb_delete.R
+++ b/R/pb_delete.R
@@ -52,7 +52,7 @@ pb_delete <- function(file = NULL,
     )
   })
 
-  cli::cli_alert_info("Deleted {.val {file}} from {.val {tag}} release on {.val {repo}}")
+  if(getOption("piggyback.verbose", default = TRUE)) cli::cli_alert_info("Deleted {.val {file}} from {.val {tag}} release on {.val {repo}}")
 
   return(invisible(TRUE))
 }

--- a/R/pb_download.R
+++ b/R/pb_download.R
@@ -32,7 +32,7 @@ pb_download <- function(file = NULL,
                         overwrite = TRUE,
                         ignore = "manifest.json",
                         use_timestamps = TRUE,
-                        show_progress = TRUE,
+                        show_progress = getOption("piggyback.verbose", default = TRUE),
                         .token = gh::gh_token()) {
 
   progress <- httr::progress("down")
@@ -78,6 +78,7 @@ pb_download <- function(file = NULL,
 
     if (dim(df)[[1]] < 1) {
       cli::cli_alert_info("All local files already up-to-date!")
+      return(invisible(NULL))
     }
   }
 
@@ -89,7 +90,7 @@ pb_download <- function(file = NULL,
                       overwrite = overwrite,
                       progress = progress
     ))
-  invisible(resp)
+  return(invisible(resp))
 }
 
 ## gh() fails on this, so we do with httr. See https://github.com/r-lib/gh/issues/57

--- a/R/pb_upload.R
+++ b/R/pb_upload.R
@@ -12,7 +12,7 @@
 #'  only overwriting those files which are older.
 #' @param use_timestamps DEPRECATED.
 #' @param show_progress logical, show a progress bar be shown for uploading?
-#' Defaults to `TRUE`.
+#' Defaults to `TRUE` - can also set globally with options("piggyback.verbose")
 #' @param .token GitHub authentication token, see `[gh::gh_token()]`
 #' @param dir directory relative to which file names should be based, defaults to NULL for current working directory.
 #' @examples
@@ -30,7 +30,7 @@ pb_upload <- function(file,
                       name = NULL,
                       overwrite = "use_timestamps",
                       use_timestamps = NULL,
-                      show_progress = TRUE,
+                      show_progress = getOption("piggyback.verbose", default = TRUE),
                       .token = gh::gh_token(),
                       dir = NULL) {
 
@@ -86,7 +86,7 @@ pb_upload_file <- function(file,
                            name = NULL,
                            overwrite = "use_timestamps",
                            use_timestamps = NULL,
-                           show_progress = TRUE,
+                           show_progress = getOption("piggyback.verbose", default = TRUE),
                            .token = gh::gh_token(),
                            dir = NULL) {
 
@@ -122,9 +122,7 @@ pb_upload_file <- function(file,
   )
 
   progress <- httr::progress("up")
-  if (!show_progress) {
-    progress <- NULL
-  }
+  if (!show_progress) progress <- NULL
 
   if (is.null(name)) {
     ## name is name on GitHub, technically need not be name of local file
@@ -162,7 +160,7 @@ pb_upload_file <- function(file,
     }
   }
 
-  if (!is.null(progress)) cli::cli_alert_info("Uploading {.file {name}} ...")
+  if (show_progress) cli::cli_alert_info("Uploading {.file {name}} ...")
 
   r <- httr::POST(sub("\\{.+$", "", df$upload_url[[1]]),
                   query = list(name = name),
@@ -172,7 +170,7 @@ pb_upload_file <- function(file,
 
   cat("\n")
 
-  if(getOption("piggyback.verbose", default = TRUE)) httr::warn_for_status(r)
+  if(show_progress) httr::warn_for_status(r)
 
   ## Release info changed, so break cache
   try({memoise::forget(pb_info)})

--- a/man/pb_download.Rd
+++ b/man/pb_download.Rd
@@ -12,7 +12,7 @@ pb_download(
   overwrite = TRUE,
   ignore = "manifest.json",
   use_timestamps = TRUE,
-  show_progress = TRUE,
+  show_progress = getOption("piggyback.verbose", default = TRUE),
   .token = gh::gh_token()
 )
 }
@@ -38,7 +38,7 @@ default \code{TRUE}.}
 \item{use_timestamps}{DEPRECATED.}
 
 \item{show_progress}{logical, show a progress bar be shown for uploading?
-Defaults to \code{TRUE}.}
+Defaults to \code{TRUE} - can also set globally with options("piggyback.verbose")}
 
 \item{.token}{GitHub authentication token, see \verb{[gh::gh_token()]}}
 }

--- a/man/pb_upload.Rd
+++ b/man/pb_upload.Rd
@@ -11,7 +11,7 @@ pb_upload(
   name = NULL,
   overwrite = "use_timestamps",
   use_timestamps = NULL,
-  show_progress = TRUE,
+  show_progress = getOption("piggyback.verbose", default = TRUE),
   .token = gh::gh_token(),
   dir = NULL
 )
@@ -34,7 +34,7 @@ only overwriting those files which are older.}
 \item{use_timestamps}{DEPRECATED.}
 
 \item{show_progress}{logical, show a progress bar be shown for uploading?
-Defaults to \code{TRUE}.}
+Defaults to \code{TRUE} - can also set globally with options("piggyback.verbose")}
 
 \item{.token}{GitHub authentication token, see \verb{[gh::gh_token()]}}
 


### PR DESCRIPTION
options("piggyback.verbose") should now consistently control verbosity across most/all functions. 