### PR TITLE
Data frame subsetting works if tibble is not installed (closes #70).

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -43,7 +43,7 @@ parse_repo <- function(repo){
 guess_repo <- function(path = ".") {
 
   exists <- requireNamespace("gert", quietly = TRUE)
-  if(!exists) stop(paste(
+  if (!exists) stop(paste(
     "Install package 'gert' to let piggyback discover the",
     "current repo, or provide your repo name explicitly"))
 
@@ -66,7 +66,7 @@ guess_repo <- function(path = ".") {
     remotes_names
   }
 
-  addr <- remotes[remotes[["name"]] == remote, "url"][["url"]]
+  addr <- remotes$url[remotes$name == remote]
 
   out <- gsub(".*[:|/]([^/]+/[^/]+)(?:\\.git$)?", "\\1", addr)
   gsub("\\.git$", "", out)


### PR DESCRIPTION
I found this issue when using `renv` in a project which does not use `tibble`. 

A `tibble` is returned at this line by `gert::git_remote_list(repo)`.

https://github.com/ropensci/piggyback/blob/4b7cdb9f45af1440f0cb6a0916c4f8b6553e60e5/R/utils.R#L51

Further down we have this:
  
https://github.com/ropensci/piggyback/blob/4b7cdb9f45af1440f0cb6a0916c4f8b6553e60e5/R/utils.R#L69

There, `remotes[remotes[["name"]] == remote, "url"]` returns a `tibble` if `tibble` is installed. If not, a `character` is returned. In the latter situation (i.e. `tibble` not installed), subsetting using `[["url"]]` is not working.

Using `remotes$url[remotes$name == remote]` fixes the issue and should work whether `tibble` is available or not.