### PR TITLE
Handle latest upload

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: piggyback
-Version: 0.1.4
+Version: 0.1.4.9001
 Title: Managing Larger Data on a GitHub Repository
 Description: Because larger (> 50 MB) data files cannot easily be committed to git,
   a different approach is required to manage data associated with an analysis in a 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# piggyback (development version)
+
+* Fix bug in `pb_upload()` to correctly resolve `"latest"` tag - if there is no release tag actually named "latest" it will use the first release from `pb_releases()`.  [#75] 
+* Make `pb_download()` and `pb_info()` also resolve `"latest"` similarly: if there is no release tag named "latest", use first release from `pb_releases()`
+
+
 # piggyback 0.1.4
 
 * The progress bar argument `show_progress` in `pb_upload()` and `pb_download()` now defaults to `interactive()` [#72]

--- a/R/pb_info.R
+++ b/R/pb_info.R
@@ -138,7 +138,7 @@ pb_info <- function(repo = guess_repo(),
   }
 
   # if tag is latest, set tag to first tag present in releases
-  if(!is.null(tag) && length(tag) == 1 && tag == "latest") tag <- releases$tag_name[[1]]
+  if(length(tag)==1 && tag == "latest" && !"latest" %in% releases$tag_name) tag <- releases$tag_name[[1]]
 
   # if tag is present, filter the releases to search to just the tags requested
   if(!is.null(tag)) releases <- releases[releases$tag_name %in% tag,]

--- a/R/pb_upload.R
+++ b/R/pb_upload.R
@@ -42,11 +42,18 @@ pb_upload <- function(file,
 
   releases <- pb_releases(repo, .token)
 
-  if(tag != "latest" && !tag %in% releases$tag_name && !interactive()) {
+  if(tag == "latest" && length(releases$tag_name) > 0 && !"latest" %in% releases$tag_name) {
+    if(getOption("piggyback.verbose", default = interactive())){
+      cli::cli_alert_info("Uploading to latest release: {.val {releases$tag_name[[1]]}}.")
+    }
+    tag <- releases$tag_name[[1]]
+  }
+
+  if(!tag %in% releases$tag_name && !interactive()) {
     cli::cli_abort("Release {.val {tag}} not found in {.val {repo}}. No upload performed.")
   }
 
-  if(tag != "latest" && !tag %in% releases$tag_name) {
+  if(!tag %in% releases$tag_name) {
     cli::cli_alert_warning("Release {.val {tag}} not found in {.val {repo}}.")
 
     run <- utils::menu(

--- a/tests/testthat/test-pb_info.R
+++ b/tests/testthat/test-pb_info.R
@@ -32,6 +32,22 @@ test_that(
 )
 
 test_that(
+  "using 'latest' will find files of the most recent release",{
+
+    skip_if_offline("api.github.com")
+
+    x <- pb_list(
+      repo = "cboettig/piggyback-tests",
+      tag = "latest",
+      .token = Sys.getenv("GITHUB_TOKEN")
+    )
+
+    expect_equivalent(unique(x$tag), "v3")
+    expect_equivalent(nrow(x), 2)
+  }
+)
+
+test_that(
   "we can list releases with default auth", {
     skip_if_offline("api.github.com")
 
@@ -44,3 +60,4 @@ test_that(
     expect_true("v0.0.1" %in% x$tag_name)
   }
 )
+

--- a/tests/testthat/test-with_auth.R
+++ b/tests/testthat/test-with_auth.R
@@ -161,6 +161,31 @@ test_that("pb_upload offering to create release if missing",{
   # but not sure how to trigger menu in test. ¯\_(ツ)_/¯
 })
 
+test_that("pb_upload finds latest release",{
+
+  skippy(TRUE)
+
+  withr::with_options(
+    list(piggyback.verbose = TRUE),
+    {
+
+      expect_warning(
+        expect_message(
+          pb_upload(
+            repo = test_repo,
+            file = upload_files,
+            tag = "latest",
+            .token = token
+          ),
+          "latest release:"
+        )
+      )
+
+    }
+  )
+
+})
+
 context("File delete")
 
 test_that("can delete files from release",{
@@ -217,23 +242,23 @@ test_that("can delete release",{
 
 context("Private repo download")
 test_that("can download private repo file",{
-#   skippy(TRUE)
-#
-#   pb_download(
-#     file = "iris_example.csv",
-#     repo = "tanho63/piggyback-private",
-#     tag = "iris",
-#     dest = tempdir(),
-#     .token = Sys.getenv("TAN_GH_TOKEN")
-#     )
-#
-#   x <- read.csv(file.path(tempdir(),"iris_example.csv"))
-#
-#   warning(paste(readLines(file.path(tempdir(),"iris_example.csv")), collapse = "\n"))
-#
-#   expect_equal(
-#     nrow(x),
-#     150
-#   )
+  #   skippy(TRUE)
+  #
+  #   pb_download(
+  #     file = "iris_example.csv",
+  #     repo = "tanho63/piggyback-private",
+  #     tag = "iris",
+  #     dest = tempdir(),
+  #     .token = Sys.getenv("TAN_GH_TOKEN")
+  #     )
+  #
+  #   x <- read.csv(file.path(tempdir(),"iris_example.csv"))
+  #
+  #   warning(paste(readLines(file.path(tempdir(),"iris_example.csv")), collapse = "\n"))
+  #
+  #   expect_equal(
+  #     nrow(x),
+  #     150
+  #   )
 
 })


### PR DESCRIPTION
This should hopefully help resolve #75 by adding handling for "latest" tag in pb_upload - looks for release named "latest" and otherwise uses the first release returned by `pb_releases()`

A tad mistimed since it went to CRAN yesterday, but alas, it’ll work for next version!

TODO: 
- [x] write a test for the default/latest tag...and try not to break the other tests while doing it...