### PR TITLE
make `pb_list()` respect option "piggyback.verbose"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: piggyback
-Version: 0.1.4.9002
+Version: 0.1.4.9003
 Title: Managing Larger Data on a GitHub Repository
 Description: Because larger (> 50 MB) data files cannot easily be committed to git,
   a different approach is required to manage data associated with an analysis in a 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Make `pb_download()` and `pb_info()` also resolve `"latest"` similarly: if there is no release tag named "latest", use first release from `pb_releases()`
 * Updated test coverage to use GHA
 * Fixed error handling for `pb_list()` for no release. 
+* `pb_list()` now respects the option `"piggyback.verbose"`
 
 
 # piggyback 0.1.4

--- a/R/pb_info.R
+++ b/R/pb_info.R
@@ -81,7 +81,8 @@ get_release_assets <- function(releases, r, .token) {
                 repo = r[[2]],
                 release_id = releases$release_id[[i]],
                 .limit = Inf,
-                .token = .token)
+                .token = .token,
+                .progress = getOption("piggyback.verbose", default = interactive()))
     if(length(a) == 0) next
     if (!identical(a[[1]], "")) {
       # convert list to dataframe and store in asset list


### PR DESCRIPTION
This PR fixes #90 

The internal function `get_release_assets` now calls `gh::gh()` with the argument `.progress`.