### PR TITLE
 `pb_release_create` warn instead of error if release already exists

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: piggyback
-Version: 0.1.4.9005
+Version: 0.1.4.9006
 Title: Managing Larger Data on a GitHub Repository
 Description: Because larger (> 50 MB) data files cannot easily be committed to git,
   a different approach is required to manage data associated with an analysis in a 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * `pb_list()` now respects the option `"piggyback.verbose"`
 * Fix download token handling [#88]
 * `pb_upload()` no longer prints out extra newlines [#93]
+* `pb_new_release()` now warns and exits early instead of failing if a release already exists. [#95]
 
 
 # piggyback 0.1.4

--- a/R/pb_release_create.R
+++ b/R/pb_release_create.R
@@ -36,7 +36,7 @@ pb_release_create <- function(repo = guess_repo(),
   # if no releases exist, pb_releases returns a dataframe of releases
   if(nrow(releases) > 0 && tag %in% releases$tag_name){
     cli::cli_warn("Failed to create release: {.val {tag}} already exists!")
-    return(invisible(releases))
+    return(invisible(releases[tag %in% releases$tag_name,]))
   }
 
   r <- parse_repo(repo)

--- a/R/pb_release_create.R
+++ b/R/pb_release_create.R
@@ -35,7 +35,8 @@ pb_release_create <- function(repo = guess_repo(),
 
   # if no releases exist, pb_releases returns a dataframe of releases
   if(nrow(releases) > 0 && tag %in% releases$tag_name){
-    cli::cli_abort("Failed to create release: {.val {tag}} already exists!")
+    cli::cli_warn("Failed to create release: {.val {tag}} already exists!")
+    return(invisible(releases))
   }
 
   r <- parse_repo(repo)
@@ -77,7 +78,7 @@ pb_release_create <- function(repo = guess_repo(),
 
   release <- httr::content(resp)
   cli::cli_alert_success("Created new release {.val {name}}.")
-  invisible(release)
+  return(invisible(release))
 }
 
 #' @export


### PR DESCRIPTION
Resolves #95. Should be reverse-compatible because it loosens restrictions on usage rather than tightening them (i.e. warn instead of stop should cause fewer, not more problems)