### PR TITLE
fixup test failures

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,6 +30,7 @@ jobs:
           - {os: ubuntu-20.04,   r: 'oldrel-1'}
     env:
       TAN_GH_TOKEN: ${{ secrets.TAN_GH_TOKEN }}
+      GITHUB_PAT: ${{ secrets.TAN_GH_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,15 +25,15 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-20.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-20.04,   r: 'release'}
-          - {os: ubuntu-18.04,   r: 'oldrel-1'}
+          - {os: ubuntu-22.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-22.04,   r: 'release'}
+          - {os: ubuntu-20.04,   r: 'oldrel-1'}
     env:
       TAN_GH_TOKEN: ${{ secrets.TAN_GH_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: piggyback
-Version: 0.1.4.9006
+Version: 0.1.4.9007
 Title: Managing Larger Data on a GitHub Repository
 Description: Because larger (> 50 MB) data files cannot easily be committed to git,
   a different approach is required to manage data associated with an analysis in a 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Fix download token handling [#88]
 * `pb_upload()` no longer prints out extra newlines [#93]
 * `pb_new_release()` now warns and exits early instead of failing if a release already exists. [#95]
+* Fixup test issues [#100]
 
 
 # piggyback 0.1.4

--- a/R/pb_upload.R
+++ b/R/pb_upload.R
@@ -40,7 +40,7 @@ pb_upload <- function(file,
     length(repo) == 1
   )
 
-  releases <- pb_releases(repo, .token)
+  releases <- pb_releases(repo = repo,.token = .token)
 
   if(tag == "latest" && length(releases$tag_name) > 0 && !"latest" %in% releases$tag_name) {
     if(getOption("piggyback.verbose", default = interactive())){
@@ -62,7 +62,7 @@ pb_upload <- function(file,
     )
 
     if(run == 2) return(invisible(NULL))
-    if(run == 1) pb_new_release(repo = repo, tag = tag, .token = .token)
+    if(run == 1) pb_release_create(repo = repo, tag = tag, .token = .token)
   }
 
   ## start fresh
@@ -137,7 +137,7 @@ pb_upload_file <- function(file,
   }
 
   ## memoised for piggyback_cache_duration
-  df <- pb_info(repo, tag, .token)
+  df <- pb_info(repo = repo, tag = tag, .token = .token)
 
   i <- which(df$file_name == name)
 
@@ -169,7 +169,7 @@ pb_upload_file <- function(file,
 
   if (show_progress) cli::cli_alert_info("Uploading {.file {name}} ...")
 
-  releases <- pb_releases(repo = repo)
+  releases <- pb_releases(repo = repo, .token = .token)
   upload_url <- releases$upload_url[releases$tag_name == tag]
 
   r <- httr::RETRY(

--- a/tests/testthat/test-pb_download.R
+++ b/tests/testthat/test-pb_download.R
@@ -34,7 +34,7 @@ test_that(
       tag = "v0.0.1",
       ignore = c("manifest.json", "big_data_file.csv"),
       show_progress = FALSE,
-      .token = Sys.getenv("GITHUB_TOKEN")
+      .token = gh::gh_token()
     )
 
     expect_true(file.exists(file.path(tmp, "iris.tsv.gz")))
@@ -56,7 +56,7 @@ test_that(
       dest = tmp,
       show_progress = FALSE,
       overwrite = TRUE,
-      .token = Sys.getenv("GITHUB_TOKEN")
+      .token = gh::gh_token()
     )
 
     expect_true(file.exists(file.path(tmp, "iris.tsv.gz")))
@@ -73,7 +73,7 @@ test_that("we can get all download urls", {
   x <- pb_download_url(
     repo = "cboettig/piggyback-tests",
     tag = "v0.0.1",
-    .token = Sys.getenv("GITHUB_TOKEN")
+    .token = gh::gh_token()
   )
   expect_is(x, "character")
   expect_gt(length(x), 1)
@@ -87,7 +87,7 @@ test_that("we can get one download url", {
     file = "iris.tsv.gz",
     repo = "cboettig/piggyback-tests",
     tag = "v0.0.1",
-    .token = Sys.getenv("GITHUB_TOKEN")
+    .token = gh::gh_token()
   )
   expect_is(x, "character")
   expect_true(length(x) == 1)
@@ -104,7 +104,7 @@ test_that("Missing files are reported in download and download_url", {
         file = "iris.csv.gz",
         repo = "cboettig/piggyback-tests",
         tag = "v0.0.1",
-        .token = Sys.getenv("GITHUB_TOKEN")
+        .token = gh::gh_token()
       )
     },
     "No download URLs"
@@ -120,7 +120,7 @@ test_that("Missing files are reported in download and download_url", {
         repo = "cboettig/piggyback-tests",
         dest = tmp,
         tag = "v0.0.1",
-        .token = Sys.getenv("GITHUB_TOKEN")
+        .token = gh::gh_token()
       )
     },
     "not found"

--- a/tests/testthat/test-pb_info.R
+++ b/tests/testthat/test-pb_info.R
@@ -23,7 +23,7 @@ test_that(
     x <- pb_list(
       repo = "cboettig/piggyback-tests",
       tag = "v0.0.1",
-      .token = Sys.getenv("GITHUB_TOKEN")
+      .token = gh::gh_token()
     )
 
     expect_true(nrow(x) > 1)
@@ -39,7 +39,7 @@ test_that(
     x <- pb_list(
       repo = "cboettig/piggyback-tests",
       tag = "latest",
-      .token = Sys.getenv("GITHUB_TOKEN")
+      .token = gh::gh_token()
     )
 
     expect_equivalent(unique(x$tag), "v3")
@@ -53,7 +53,7 @@ test_that(
 
     x <- pb_releases(
       repo = "cboettig/piggyback-tests",
-      .token = Sys.getenv("GITHUB_TOKEN")
+      .token = gh::gh_token()
     )
 
     expect_true(nrow(x) > 1)
@@ -68,17 +68,11 @@ test_that(
     expect_warning(
     x <- pb_releases(
       repo = "tanho63/tanho63",
-      .token = Sys.getenv("GITHUB_TOKEN")
+      .token = gh::gh_token()
     ),
     "No GitHub releases"
     )
-
     expect_equivalent(nrow(x), 0)
-
-    x <- pb_list(
-      repo = "tanho63/tanho63",
-      .token = Sys.getenv("GITHUB_TOKEN")
-    )
   }
 )
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -15,6 +15,7 @@ test_that("guess_repo works",{
   fs::dir_create(repo_path)
 
   gert::git_clone(url = "https://github.com/cboettig/piggyback-tests",
+                  password = gh::gh_token(),
                   path = repo_path)
 
   on.exit(unlink(repo_path, recursive = TRUE))

--- a/tests/testthat/test-with_auth.R
+++ b/tests/testthat/test-with_auth.R
@@ -44,7 +44,7 @@ test_that("We can create a new release",{
 test_that("Error if we try to create an existing release",{
   skippy(TRUE)
 
-  expect_condition(
+  expect_warning(
     pb_release_create(repo = test_repo, tag = test_release_tag, .token = token),
     "Failed to create"
   )


### PR DESCRIPTION
Changelog:
- use expect_warning instead of expect_condition, which should resolve #100 (assume it was because of a change in how gh uses httr2 now and raises that as a warning?)
- use gh::gh_token() in tests for consistency and to hope that it avoids rate limiting 


Investigating #101 separately from this, think it’s a memoising thing. 