### PR TITLE
pb_upload no longer interactively creates releases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: piggyback
-Version: 0.1.5.9001
+Version: 0.1.5.9002
 Title: Managing Larger Data on a GitHub Repository
 Description: Because larger (> 50 MB) data files cannot easily be committed to git,
   a different approach is required to manage data associated with an analysis in a 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # piggyback (development version)
 
-* Fix bug in pb_releases to allow for draft releases to appear [#105]
+* Fix bug in `pb_releases()` to allow for draft releases to appear [#105]
+* `pb_upload()` no longer offers to create a release if interactive - it now 
+provides the code to create the release in the error body.
 
 # piggyback 0.1.5
 

--- a/R/pb_upload.R
+++ b/R/pb_upload.R
@@ -49,21 +49,12 @@ pb_upload <- function(file,
     tag <- releases$tag_name[[1]]
   }
 
-  if(!tag %in% releases$tag_name && !interactive()) {
-    cli::cli_abort("Release {.val {tag}} not found in {.val {repo}}. No upload performed.")
-  }
-
   if(!tag %in% releases$tag_name) {
-    cli::cli_alert_warning("Release {.val {tag}} not found in {.val {repo}}.")
-
-    run <- utils::menu(
-      choices = c("Yes", "No"),
-      title = glue::glue("Would you like to create a new release now?")
+    cli::cli_abort(
+      c("x" = "Could not find {.val {tag}} in {.code pb_releases('{repo}')}!",
+        "i" = "To create a new release, use {.run pb_release_create('{repo}', '{tag}')}",
+        "*"= "No upload was performed.")
     )
-
-    if(run == 2) return(invisible(NULL))
-    if(run == 1) pb_release_create(repo = repo, tag = tag, .token = .token)
-    Sys.sleep(2)
   }
 
   ## start fresh

--- a/tests/testthat/test-with_auth.R
+++ b/tests/testthat/test-with_auth.R
@@ -152,13 +152,8 @@ test_that("cannot upload to nonexistent release", {
       show_progress = FALSE,
       .token = token
     ),
-    "Release .* not found"
+    "Could not find .* in.*pb_releases"
   )
-})
-
-test_that("pb_upload offering to create release if missing",{
-  # would ideally test with rlang::with_interactive() etc
-  # but not sure how to trigger menu in test. ¯\_(ツ)_/¯
 })
 
 test_that("pb_upload finds latest release",{


### PR DESCRIPTION
resolves #104: eliminates the behaviour of offering to create a new release interactively