### PR TITLE
`pb_download_url` returns choice of browser or api download urls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: piggyback
-Version: 0.1.5.9003
+Version: 0.1.5.9004
 Title: Managing Larger Data on a GitHub Repository
 Description: Because larger (> 50 MB) data files cannot easily be committed to git,
   a different approach is required to manage data associated with an analysis in a 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ provides the code to create the release in the error body.
 before trying API download URLs. This should reduce/eliminate effect of API rate
 limits for pb_download. [#109]
 * `"latest"` release now aligns with GitHub's "latest" release definition [#113]
+* `pb_download_url()` now can return choice of "browser" or "api" download URLs [#116]
 
 # piggyback 0.1.5
 

--- a/R/pb_download_url.R
+++ b/R/pb_download_url.R
@@ -13,11 +13,34 @@
 #' @examples \donttest{
 #' \dontshow{try(\{}
 #'
-#' # returns browser url by default
-#' pb_download_url("iris.tsv.xz", repo = "cboettig/piggyback-tests", tag = "v0.0.1")
+#' # returns browser url by default (and all files if none are specified)
+#' browser_url <- pb_download_url(
+#'   repo = "tanho63/piggyback-tests",
+#'   tag = "v0.0.2"
+#'   )
+#' print(browser_url)
+#' utils::read.csv(browser_url[[1]])
 #'
 #' # can return api url if desired
-#' pb_download_url("iris.tsv.xz", repo = "cboettig/piggyback-tests", tag = "v0.0.1", url_type = "api")
+#' api_url <- pb_download_url(
+#'   "mtcars.csv",
+#'   repo = "tanho63/piggyback-tests",
+#'   tag = "v0.0.2"
+#'   )
+#' print(api_url)
+#'
+#' # for public repositories, this will still work
+#' utils::read.csv(api_url)
+#'
+#' # for private repos, can use httr or curl to fetch and then pass into read function
+#' gh_pat <- Sys.getenv("GITHUB_PAT")
+#'
+#' if(!identical(gh_pat, "")){
+#'   resp <- httr::GET(api_url, httr::add_headers(Authorization = paste("Bearer", gh_pat)))
+#'   utils::read.csv(text = httr::content(resp, as = "text"))
+#' }
+#'
+#' # or use pb_read which bundles some of this for you
 #'
 #' \dontshow{\})}
 #' }

--- a/R/pb_info.R
+++ b/R/pb_info.R
@@ -106,6 +106,9 @@ get_release_assets <- function(releases, r, .token) {
         repo = r[[2]],
         upload_url = releases$upload_url[i],
         browser_download_url = .extract_chr(a, "browser_download_url"),
+        api_download_url = glue::glue(
+          "https://api.github.com/repos/{r[[1]]}/{r[[2]]}/releases/assets/{.extract_int(a, 'id')}"
+        ),
         id = .extract_int(a, "id"),
         state = .extract_chr(a, "state"),
         stringsAsFactors = FALSE
@@ -143,6 +146,7 @@ pb_info <- function(repo = guess_repo(),
         repo = r[[2]],
         upload_url = "",
         browser_download_url = "",
+        api_download_url = "",
         id = "",
         state = "",
         stringsAsFactors = FALSE

--- a/man/pb_download.Rd
+++ b/man/pb_download.Rd
@@ -45,7 +45,7 @@ Download data from an existing release
 }
 \examples{
 \donttest{
- try({ # this try block is to avoid errors on CRAN, not needed for normal use
+\dontshow{try(\{}
    ## Download a specific file.
    ## (if dest is omitted, will write to current directory)
    dest <- tempdir()
@@ -63,8 +63,8 @@ Download data from an existing release
      dest = dest
    )
    list.files(dest)
- })
- \dontshow{
+\dontshow{\})}
+\dontshow{
    try(unlink(list.files(dest, full.names = TRUE)))
  }
 }

--- a/man/pb_download_url.Rd
+++ b/man/pb_download_url.Rd
@@ -8,6 +8,7 @@ pb_download_url(
   file = NULL,
   repo = guess_repo(),
   tag = "latest",
+  url_type = c("browser", "api"),
   .token = gh::gh_token()
 )
 }
@@ -20,22 +21,30 @@ tries to guess based on current working directory's git repository}
 
 \item{tag}{string: tag for the GH release, defaults to "latest"}
 
+\item{url_type}{choice: one of "browser" or "api" - default "browser" is a
+web-facing URL that is not subject to API ratelimits but does not work for
+private repositories. "api" URLs work for private repos, but require a GitHub
+token passed in an Authorization header (see examples)}
+
 \item{.token}{GitHub authentication token, see \code{\link[gh:gh_token]{gh::gh_token()}}}
 }
 \value{
 the URL to download a file
 }
 \description{
-Returns the URL download for a public file. This can be useful when writing
-scripts that may want to download the file directly without introducing any
-dependency on \code{piggyback} or authentication steps.
+Returns the URL download for a given file. This can be useful when using
+functions that are able to accept URLs.
 }
 \examples{
-\dontrun{
+\donttest{
+\dontshow{try(\{}
 
-pb_download_url("iris.tsv.xz",
-                repo = "cboettig/piggyback-tests",
-                tag = "v0.0.1")
+# returns browser url by default
+pb_download_url("iris.tsv.xz", repo = "cboettig/piggyback-tests", tag = "v0.0.1")
 
+# can return api url if desired
+pb_download_url("iris.tsv.xz", repo = "cboettig/piggyback-tests", tag = "v0.0.1", url_type = "api")
+
+\dontshow{\})}
 }
 }


### PR DESCRIPTION
Resolves #116.

Adds handling so that pb_download_url can be more useful with private repos. Not 100% sure how the auth header would be passed in a cloud-native setup yet (might never be) but at least we can document ways to skip disk read now. 