### PR TITLE
Fix link to Getting Started page

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -49,7 +49,7 @@ install.packages("piggyback", repos = c('https://ropensci.r-universe.dev', getOp
 remotes::install_github("ropensci/piggyback")
 ```
 ## Usage
-See [getting started vignette](https://docs.ropensci.org/piggyback/articles/intro.html)
+See [getting started vignette](https://docs.ropensci.org/piggyback/articles/piggyback.html)
 for a more comprehensive introduction.
 
 Download data attached to a GitHub release:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ remotes::install_github("ropensci/piggyback")
 ## Usage
 
 See [getting started
-vignette](https://docs.ropensci.org/piggyback/articles/intro.html) for a
+vignette](https://docs.ropensci.org/piggyback/articles/piggyback.html) for a
 more comprehensive introduction.
 
 Download data attached to a GitHub release:


### PR DESCRIPTION
The current link goes to a page that doesn't exist